### PR TITLE
Photosynthesis fix

### DIFF
--- a/src/biogeochem/CNPhenologyMod.F90
+++ b/src/biogeochem/CNPhenologyMod.F90
@@ -852,19 +852,24 @@ contains
                ! the summer solstice without reaching the threshold value.
                ! In that case, it will take until the next winter solstice
                ! before the growing degree-day summation starts again.
-
-               if (onset_gddflag(p) == 1._r8 .and. ws_flag == 0._r8) then
-                  onset_gddflag(p) = 0._r8
-                  onset_gdd(p) = 0._r8
-               end if
+!WW turned off to onset can occur after summer solstice
+!               if (onset_gddflag(p) == 1._r8 .and. ws_flag == 0._r8) then
+!                  onset_gddflag(p) = 0._r8
+!                  onset_gdd(p) = 0._r8
+!               end if
 
                ! if the gdd flag is set, and if the soil is above freezing
                ! then accumulate growing degree days for onset trigger
 
                soilt = t_soisno(c, phenology_soil_layer)
-               if (onset_gddflag(p) == 1.0_r8 .and. soilt > SHR_CONST_TKFRZ) then
-                  onset_gdd(p) = onset_gdd(p) + (soilt-SHR_CONST_TKFRZ)*fracday
+               if (onset_gddflag(p) == 1.0_r8 .and. soilt > 277._r8) then !WW added
+!              if (onset_gddflag(p) == 1.0_r8 .and. soilt > SHR_CONST_TKFRZ + 1._r8) then !WW added
+                  onset_gdd(p) = onset_gdd(p) + (soilt-SHR_CONST_TKFRZ )*fracday  
                end if
+
+!               if (onset_gddflag(p) == 1.0_r8 .and. soilt > SHR_CONST_TKFRZ) then
+!                  onset_gdd(p) = onset_gdd(p) + (soilt-SHR_CONST_TKFRZ)*fracday
+!               end if
 
                ! set onset_flag if critical growing degree-day sum is exceeded
                if (onset_gdd(p) > crit_onset_gdd) then
@@ -914,6 +919,7 @@ contains
                end if
 
                ! only begin to test for offset daylength once past the summer sol
+	       ! WW critical day length = 10.9 hours on parameter file
                if (ws_flag == 0._r8 .and. dayl(g) < crit_dayl) then
                   offset_flag(p) = 1._r8
                   offset_counter(p) = ndays_off * secspday

--- a/src/biogeophys/PhotosynthesisMod.F90
+++ b/src/biogeophys/PhotosynthesisMod.F90
@@ -1610,6 +1610,8 @@ contains
 
                !now the constraint is no longer needed, Jinyun Tang
                ceair = min( eair(p),  esat_tv(p) )
+               ceair = esat_tv(p)       !WW added, turn of rh effect on psn 
+
                if (      stomatalcond_mtd == stomatalcond_mtd_bb1987 )then
                   rh_can = ceair / esat_tv(p)
                else if ( stomatalcond_mtd == stomatalcond_mtd_medlyn2011 )then

--- a/src/biogeophys/SoilStateType.F90
+++ b/src/biogeophys/SoilStateType.F90
@@ -231,12 +231,13 @@ contains
             ptr_col=this%bsw_col, default='inactive')
     end if
 
-    if (use_dynroot) then
+! WW turned off to make ROOTFR = active
+!    if (use_dynroot) then
        this%rootfr_patch(begp:endp,:) = spval
        call hist_addfld2d (fname='ROOTFR', units='proportion', type2d='levgrnd', &
             avgflag='A', long_name='fraction of roots in each soil layer', &
             ptr_patch=this%rootfr_patch, default='active')
-    end if
+!    end if
 
     if ( use_dynroot ) then
        this%root_depth_patch(begp:endp) = spval
@@ -249,7 +250,7 @@ contains
        this%rootr_patch(begp:endp,:) = spval
        call hist_addfld2d (fname='ROOTR', units='proportion', type2d='levgrnd', &
             avgflag='A', long_name='effective fraction of roots in each soil layer (SMS method)', &
-            ptr_patch=this%rootr_patch, l2g_scale_type='veg', default='inactive')
+            ptr_patch=this%rootr_patch, l2g_scale_type='veg', default='active') ! WW made active
     end if
 
     if (use_cn .and. .not.(use_hydrstress)) then


### PR DESCRIPTION
### Description of changes
Implements Will Wieder's changes for adapting CLM to run at Niwot Ridge.

### Specific notes
The changes are as follows:
In PhotosynthesisMod.F90: WW modified ceair calculation to turn off rh effect on psn 
In CNPhenologyMod.F90: WW turned off onset_gddflag so that growth onset can occur after the solstice.
In SoilStateType.F90: WW turned off use_dynroot option to make ROOTFR always active


Contributors other than yourself, if any: Will Wieder

CTSM Issues Fixed (include github issue #):

Are answers expected to change (and if so in what way)?
Plants are expected to grow after the solstice, root dynamics will change, and Photosynthesis dynamics will change.

Any User Interface Changes (namelist or namelist defaults changes)?

Testing performed, if any:
(List what testing you did to show your changes worked as expected)
(This can be manual testing or running of the different test suites)
(Documentation on system testing is here: https://github.com/ESCOMP/ctsm/wiki/System-Testing-Guide)
(aux_clm on cheyenne for intel/gnu and izumi for intel/gnu/nag/pgi is the standard for tags on master)

**NOTE: Be sure to check your coding style against the standard
(https://github.com/ESCOMP/ctsm/wiki/CTSM-coding-guidelines) and review
the list of common problems to watch out for
(https://github.com/ESCOMP/CTSM/wiki/List-of-common-problems).**
